### PR TITLE
updating dropbox client to latest 30.4.23 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,13 @@ FROM debian:jessie
 MAINTAINER chris turra <cturra@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV DROPBOX_VERSION 30.4.23
 ENV ARCH            86_64
 
-RUN apt-get -qq update             \
- && apt-get -yf install supervisor \
-                        wget       \
+RUN apt-get -q update               \
+ && apt-get -y install libglib2.0-0 \
+                       supervisor   \
+                       wget         \
  && rm -rf /var/lib/apt/lists/*
 
 COPY conf/dropboxd.conf /etc/supervisor/conf.d/dropboxd.conf
@@ -15,9 +17,9 @@ COPY conf/dropboxd.conf /etc/supervisor/conf.d/dropboxd.conf
 # download and install dropbox (headless)
 # more details about this installation at:
 # - https://www.dropbox.com/install?os=lnx
-RUN wget -O /tmp/dropbox.tgz                                   \
-         -q https://www.dropbox.com/download?plat=lnx.x${ARCH} \
- && tar -zxf /tmp/dropbox.tgz -C /root/                        \
+RUN wget -O /tmp/dropbox.tgz            \
+         -q https://clientupdates.dropboxstatic.com/dbx-releng/client/dropbox-lnx.x${ARCH}-${DROPBOX_VERSION}.tar.gz \
+ && tar -zxf /tmp/dropbox.tgz -C /root/ \
  && rm -f /tmp/dropbox.tgz
 
 # download the Dropbox python management script


### PR DESCRIPTION
we now apparently need to have `libglib` present also... neat.