### PR TITLE
dropbox client upgraded to 39.4.49

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM debian:stretch
+FROM debian:stretch-slim
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV DROPBOX_VERSION 38.4.27
+ENV DROPBOX_VERSION 39.4.49
 ENV ARCH            86_64
 
 RUN apt-get -q update               \


### PR DESCRIPTION
also included in this release is an update to the stretch-slim base image from stretch. this reduces the overall size of the resulting docker image from 361MB -> 296MB. `#winning`