### PR TITLE
moving .dropbox-dist directory from /root to /dropbox

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,6 +2,7 @@ The following awesome folks have contributed ideas,
 bug reports and code to this dropbox docker project:
 
  - Chris Turra  => https://github.com/cturra
+ - Di Xu        => https://github.com/dixudx
  - Ryan Neufeld => https://github.com/ryanneufeld
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV DROPBOX_VERSION 39.4.49
+ENV DROPBOX_VERSION 53.4.67
 ENV ARCH            86_64
 
 RUN apt-get -q update               \
@@ -23,6 +23,9 @@ RUN wget -O /tmp/dropbox.tgz            \
 # download the Dropbox python management script
 RUN wget -O /root/dropbox.py \
          -q http://www.dropbox.com/download?dl=packages/dropbox.py
+
+# move .dropbox-dist directory to /dropbox
+RUN mv -f /root/.dropbox-dist /dropbox
 
 # kick off supervisord+dropbox
 ENTRYPOINT [ "/usr/bin/supervisord" ]


### PR DESCRIPTION
thanks for reporting this @dixudx

additionally, this pull request also upgrades the dropbox client from `39.4.49` to `53.4.67`